### PR TITLE
Fix model build

### DIFF
--- a/src/ceddl.c
+++ b/src/ceddl.c
@@ -179,7 +179,7 @@ extern "C" {
         optimizer_ptr o, const char* type,
         const char** lo, int lo_count,
         const char** me, int me_count,
-        compserv_ptr cs
+        compserv_ptr cs, bool init_weights
     ) {
         const std::string type_str = string(type);
         std::vector<string> lo_vector = std::vector<string>();
@@ -203,7 +203,7 @@ extern "C" {
             // type_str == "RMSProp"
             myOptimizer = static_cast<RMSProp *>(o);
         }
-        eddl::build(static_cast<eddl::model>(net), myOptimizer, lo_vector, me_vector, static_cast<eddl::compserv>(cs));
+        eddl::build(static_cast<eddl::model>(net), myOptimizer, lo_vector, me_vector, static_cast<eddl::compserv>(cs), init_weights);
     }
 
     // Computing services

--- a/src/ceddl.c
+++ b/src/ceddl.c
@@ -60,6 +60,8 @@ eddl::layer transformLayer(layer_ptr l, string type) {
         myLayer = static_cast<LBatchNorm *>(l);
     } else if (type == "UpSampling") {
         myLayer = static_cast<LUpSampling *>(l);
+    } else {
+        myLayer = static_cast<eddl::layer>(l);
     }
     return myLayer;
 }

--- a/src/ceddl.h
+++ b/src/ceddl.h
@@ -71,7 +71,7 @@ extern "C" {
         optimizer_ptr o, const char* type,
         const char** lo, int lo_count,
         const char** me, int me_count,
-        compserv_ptr cs
+        compserv_ptr cs, bool init_weights=true
     );
     
     // Computing services


### PR DESCRIPTION
# Overview
- Added a missing parameter to the `ceddl_build` function to support `ONNX` model builds.
- Added a final `else` in the `transformLayer` function. If the `type` parameter is an empty or not supported string, the function gives an error without it.